### PR TITLE
fix: stop propagating request to backend if not valid

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,11 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>io.gravitee.gateway</groupId>

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -4,7 +4,7 @@
   "properties": {
     "regex": {
       "title": "Regex",
-      "description": "Regex used to detect malicious injections. You can enable this regular expression on headers, path and body or add multiple Regex Threat Protection Policies with different regex depending on your needs.<br><br>Some regex detection examples:<ul><li>SQL Injection: <code>.*[\\s]*((delete)|(exec)|(drop\\s*table)|(insert)|(shutdown)|(update)|(\\bor\\b)).*</code></li><li>Server-Side Include Injection: <code>.*&lt;!--#(include|exec|echo|config|printenv)\\s+.*</code></li><li>Java Exception Injection<code>.*Exception in thread.*</code></li><li>Javascript Injection<code>.*<\\s*script\\b[^>]*>[^<]+<\\s*/\\s*script\\s*>.*</code></li><li>XPath Injection: <code>.*(/(@?[\\w_?\\w:\\*]+(\\[[^]]+\\])*)?)+.*</code></li></ul>",
+      "description": "Regex used to detect malicious injections. You can enable this regular expression on headers, path and body or add multiple Regex Threat Protection Policies with different regex depending on your needs.<br><br>Some regex detection examples:<ul><li>SQL Injection: <code>.*[\\s]*((delete)|(exec)|(drop\\s*table)|(insert)|(shutdown)|(update)|(\\bor\\b)).*</code></li><li>Server-Side Include Injection: <code>.*&lt;!--#(include|exec|echo|config|printenv)\\s+.*</code></li><li>Java Exception Injection: <code>.*Exception in thread.*</code></li><li>Javascript Injection: <code>.*<\\s*script\\b[^>]*>[^<]+<\\s*/\\s*script\\s*>.*</code></li><li>XPath Injection: <code>.*(/(@?[\\w_?\\w:\\*]+(\\[[^]]+\\])*)?)+.*</code></li></ul>",
       "type": "string",
       "format": "java-regex"
     },


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7301


<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.3.1-issues-7301-stop-propagate-request-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-regex-threat-protection/1.3.1-issues-7301-stop-propagate-request-SNAPSHOT/gravitee-policy-regex-threat-protection-1.3.1-issues-7301-stop-propagate-request-SNAPSHOT.zip)
  <!-- Version placeholder end -->
