### PR TITLE
 fix: stop propagating request to backend if not valid

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,63 +1,35 @@
 version: 2.1
 
-parameters:
-  gio_action:
-    type: enum
-    enum: [release, pr_build]
-    default: pr_build
-  dry_run:
-    type: boolean
-    default: true
-    description: "Run in dry run mode?"
-  maven_profile_id:
-    type: string
-    default: "gravitee-dry-run"
-    description: "Maven ID of the Maven profile to use for a dry run ?"
-  secrethub_org:
-    type: string
-    default: "gravitee-lab"
-    description: "SecretHub Org to use to fetch secrets ?"
-  secrethub_repo:
-    type: string
-    default: "cicd"
-    description: "SecretHub Repo to use to fetch secrets ?"
+# this allows you to use CircleCI's dynamic configuration feature
+setup: true
 
 orbs:
-  gravitee: gravitee-io/gravitee@dev:1.0.4
+    gravitee: gravitee-io/gravitee@2.0
 
+# our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
+# some workflow and job will not be triggered for tags (default CircleCI behavior)
 workflows:
-  version: 2.1
-  pull_requests:
-    when:
-      equal: [ pr_build, << pipeline.parameters.gio_action >> ]
-    jobs:
-      - gravitee/pr-build:
-          context: cicd-orchestrator
-  release:
-    # see https://circleci.com/docs/2.0/configuration-reference/#logic-statement-examples
-    when:
-      and:
-        - equal: [ release, << pipeline.parameters.gio_action >> ]
-        - not: << pipeline.parameters.dry_run >>
-    jobs:
-      # return to simple definition :
-      - gravitee/release:
-          context: cicd-orchestrator
-          dry_run: << pipeline.parameters.dry_run >>
-          secrethub_org: << pipeline.parameters.secrethub_org >>
-          secrethub_repo: << pipeline.parameters.secrethub_repo >>
-          maven_profile_id: << pipeline.parameters.maven_profile_id >>
-  release_dry_run:
-    # see https://circleci.com/docs/2.0/configuration-reference/#logic-statement-examples
-    when:
-      and:
-        - equal: [ release, << pipeline.parameters.gio_action >> ]
-        - << pipeline.parameters.dry_run >>
-    jobs:
-      # return to simple definition :
-      - gravitee/release:
-          context: cicd-orchestrator
-          dry_run: << pipeline.parameters.dry_run >>
-          secrethub_org: << pipeline.parameters.secrethub_org >>
-          secrethub_repo: << pipeline.parameters.secrethub_repo >>
-          maven_profile_id: << pipeline.parameters.maven_profile_id >>
+    setup_build:
+        when:
+            not: << pipeline.git.tag >>
+        jobs:
+            - gravitee/setup_plugin-build-config:
+                  filters:
+                      tags:
+                          ignore:
+                              - /.*/
+
+    setup_release:
+        when:
+            matches:
+                pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+                value: << pipeline.git.tag >>
+        jobs:
+            - gravitee/setup_plugin-release-config:
+                  filters:
+                      branches:
+                          ignore:
+                              - /.*/
+                      tags:
+                          only:
+                              - /^[0-9]+\.[0-9]+\.[0-9]+$/

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default
+*       @gravitee-io/apim @gravitee-io/archi

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+**Issue**
+
+https://github.com/gravitee-io/issues/issues/XXXXX
+
+**Description**
+
+A small description of what you did in that PR.
+
+**Additional context**
+
+<!-- Add any other context about the PR here -->
+<!-- It can be links to other PRs or docs or drawing -->
+<!-- Or reproduction steps in case of bug fix -->

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,14 @@
 {
-  "extends": ["config:base", "schedule:earlyMondays"],
+  "extends": [
+    "config:base",
+    "schedule:earlyMondays"
+  ],
   "prConcurrentLimit": 3,
-  "rebaseWhen": "conflicted"
+  "rebaseWhen": "conflicted",
+  "packageRules": [
+    {
+      "matchDatasources": ["orb"],
+      "rangeStrategy": "replace"
+    }
+  ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,5 @@
+{
+  "extends": ["config:base", "schedule:earlyMondays"],
+  "prConcurrentLimit": 3,
+  "rebaseWhen": "conflicted"
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,2 @@
+printWidth: 140
+tabWidth: 4

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.adoc
+++ b/README.adoc
@@ -1,8 +1,10 @@
 = Regex threat protection policy
 
 ifdef::env-github[]
-image:https://ci.gravitee.io/buildStatus/icon?job=gravitee-io/gravitee-policy-regex-threat-protection/master["Build status", link="https://ci.gravitee.io/job/gravitee-io/job/gravitee-policy-regex-threat-protection/"]
-image:https://badges.gitter.im/Join Chat.svg["Gitter", link="https://gitter.im/gravitee-io/gravitee-io?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"]
+image:https://img.shields.io/static/v1?label=Available%20at&message=Gravitee.io&color=1EC9D2["Gravitee.io", link="https://download.gravitee.io/#graviteeio-apim/plugins/policies/gravitee-policy-regex-threat-protection/"]
+image:https://img.shields.io/badge/License-Apache%202.0-blue.svg["License", link="https://github.com/gravitee-io/gravitee-policy-regex-threat-protection/blob/master/LICENSE.txt"]
+image:https://img.shields.io/badge/semantic--release-conventional%20commits-e10079?logo=semantic-release["Releases", link="https://github.com/gravitee-io/gravitee-policy-regex-threat-protection/releases"]
+image:https://circleci.com/gh/gravitee-io/gravitee-policy-regex-threat-protection.svg?style=svg["CircleCI", link="https://circleci.com/gh/gravitee-io/gravitee-policy-regex-threat-protection"]
 endif::[]
 
 == Phase

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.gravitee.policy</groupId>
     <artifactId>gravitee-policy-regex-threat-protection</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.2.1</version>
 
     <name>Gravitee.io APIM - Policy - RegexThreatProtection</name>
     <description>Description of the RegexThreatProtection Gravitee Policy</description>
@@ -40,6 +40,8 @@
         <junit.version>4.12</junit.version>
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
         <gravitee-gateway-buffer.version>3.0.13</gravitee-gateway-buffer.version>
+        <!-- Property used by the publication job in CI-->
+        <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,23 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.hubspot.maven.plugins</groupId>
+                <artifactId>prettier-maven-plugin</artifactId>
+                <version>0.17</version>
+                <configuration>
+                    <nodeVersion>12.13.0</nodeVersion>
+                    <prettierJavaVersion>1.6.1</prettierJavaVersion>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,11 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>io.gravitee.gateway</groupId>

--- a/src/main/java/io/gravitee/policy/threatprotection/regex/RegexThreatProtectionPolicy.java
+++ b/src/main/java/io/gravitee/policy/threatprotection/regex/RegexThreatProtectionPolicy.java
@@ -21,8 +21,9 @@ import io.gravitee.common.util.MultiValueMap;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.api.buffer.Buffer;
-import io.gravitee.gateway.api.http.stream.TransformableRequestStreamBuilder;
+import io.gravitee.gateway.api.stream.BufferedReadWriteStream;
 import io.gravitee.gateway.api.stream.ReadWriteStream;
+import io.gravitee.gateway.api.stream.SimpleReadWriteStream;
 import io.gravitee.policy.api.PolicyChain;
 import io.gravitee.policy.api.PolicyResult;
 import io.gravitee.policy.api.annotations.OnRequest;
@@ -76,10 +77,17 @@ public class RegexThreatProtectionPolicy {
     @OnRequestContent
     public ReadWriteStream<Buffer> onRequestContent(Request request, PolicyChain policyChain) {
         if (configuration.isCheckBody()) {
-            return TransformableRequestStreamBuilder
-                .on(request)
-                .chain(policyChain)
-                .transform(buffer -> {
+            return new BufferedReadWriteStream() {
+                final Buffer buffer = Buffer.buffer();
+
+                @Override
+                public SimpleReadWriteStream<Buffer> write(Buffer content) {
+                    buffer.appendBuffer(content);
+                    return this;
+                }
+
+                @Override
+                public void end() {
                     // Load the body in memory and execute the regex on it.
                     if (configuration.getPattern().matcher(buffer.toString()).matches()) {
                         policyChain.streamFailWith(
@@ -90,11 +98,14 @@ public class RegexThreatProtectionPolicy {
                                 MediaType.TEXT_PLAIN
                             )
                         );
+                    } else {
+                        if (buffer.length() > 0) {
+                            super.write(buffer);
+                        }
+                        super.end();
                     }
-
-                    return buffer;
-                })
-                .build();
+                }
+            };
         }
 
         return null;

--- a/src/main/java/io/gravitee/policy/threatprotection/regex/RegexThreatProtectionPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/threatprotection/regex/RegexThreatProtectionPolicyConfiguration.java
@@ -18,9 +18,8 @@ package io.gravitee.policy.threatprotection.regex;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
-import io.gravitee.policy.api.PolicyConfiguration;
 import io.gravitee.common.http.HttpMethod;
-
+import io.gravitee.policy.api.PolicyConfiguration;
 import java.util.regex.Pattern;
 
 /**
@@ -70,9 +69,7 @@ public class RegexThreatProtectionPolicyConfiguration implements PolicyConfigura
      * @return the compiled regex.
      */
     public Pattern getPattern() {
-
         if (pattern == null) {
-
             int flags = 0;
 
             if (!caseSensitive) {

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -4,7 +4,7 @@
   "properties": {
     "regex": {
       "title": "Regex",
-      "description": "Regex used to detect malicious injections. You can enable this regular expression on headers, path and body or add multiple Regex Threat Protection Policies with different regex depending on your needs.<br><br>Some regex detection examples:<ul><li>SQL Injection: <code>.*[\\s]*((delete)|(exec)|(drop\\s*table)|(insert)|(shutdown)|(update)|(\\bor\\b)).*</code></li><li>Server-Side Include Injection: <code>.*&lt;!--#(include|exec|echo|config|printenv)\\s+.*</code></li><li>Java Exception Injection<code>.*Exception in thread.*</code></li><li>Javascript Injection<code>.*<\\s*script\\b[^>]*>[^<]+<\\s*/\\s*script\\s*>.*</code></li><li>XPath Injection: <code>.*(/(@?[\\w_?\\w:\\*]+(\\[[^]]+\\])*)?)+.*</code></li></ul>",
+      "description": "Regex used to detect malicious injections. You can enable this regular expression on headers, path and body or add multiple Regex Threat Protection Policies with different regex depending on your needs.<br><br>Some regex detection examples:<ul><li>SQL Injection: <code>.*[\\s]*((delete)|(exec)|(drop\\s*table)|(insert)|(shutdown)|(update)|(\\bor\\b)).*</code></li><li>Server-Side Include Injection: <code>.*&lt;!--#(include|exec|echo|config|printenv)\\s+.*</code></li><li>Java Exception Injection: <code>.*Exception in thread.*</code></li><li>Javascript Injection: <code>.*<\\s*script\\b[^>]*>[^<]+<\\s*/\\s*script\\s*>.*</code></li><li>XPath Injection: <code>.*(/(@?[\\w_?\\w:\\*]+(\\[[^]]+\\])*)?)+.*</code></li></ul>",
       "type": "string",
       "format": "java-regex"
     },

--- a/src/test/java/io/gravitee/policy/threatprotection/regex/RegexThreatProtectionPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/threatprotection/regex/RegexThreatProtectionPolicyTest.java
@@ -15,6 +15,10 @@
  */
 package io.gravitee.policy.threatprotection.regex;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.*;
+
 import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.util.LinkedMultiValueMap;
 import io.gravitee.common.util.MultiValueMap;
@@ -32,10 +36,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RegexThreatProtectionPolicyTest {
@@ -57,7 +57,6 @@ public class RegexThreatProtectionPolicyTest {
 
     @Before
     public void before() {
-
         configuration = new RegexThreatProtectionPolicyConfiguration();
         configuration.setRegex(EVIL_REGEX);
         configuration.setCheckHeaders(false);
@@ -69,7 +68,6 @@ public class RegexThreatProtectionPolicyTest {
 
     @Test
     public void shouldAcceptAllWhenNoCheck() {
-
         ReadWriteStream<?> readWriteStream = cut.onRequestContent(request, policyChain);
         cut.onRequest(request, response, policyChain);
 
@@ -82,7 +80,6 @@ public class RegexThreatProtectionPolicyTest {
 
     @Test
     public void shouldCheckAndAcceptHeaders() {
-
         when(request.headers()).thenReturn(createHttpHeaders());
         configuration.setCheckHeaders(true);
 
@@ -98,7 +95,6 @@ public class RegexThreatProtectionPolicyTest {
 
     @Test
     public void shouldRejectEvilHeaderName() {
-
         HttpHeaders headers = createHttpHeaders();
         headers.add("header-evil", "jkl");
 
@@ -117,7 +113,6 @@ public class RegexThreatProtectionPolicyTest {
 
     @Test
     public void shouldRejectEvilHeaderValue() {
-
         HttpHeaders headers = createHttpHeaders();
         headers.add("header2", "jkl-evil");
 
@@ -136,7 +131,6 @@ public class RegexThreatProtectionPolicyTest {
 
     @Test
     public void shouldCheckAndAcceptPathAndParams() {
-
         when(request.pathInfo()).thenReturn("/path");
         when(request.parameters()).thenReturn(createParams());
         configuration.setCheckPath(true);
@@ -153,7 +147,6 @@ public class RegexThreatProtectionPolicyTest {
 
     @Test
     public void shouldRejectEvilPath() {
-
         when(request.pathInfo()).thenReturn("/path-evil");
         configuration.setCheckPath(true);
 
@@ -169,7 +162,6 @@ public class RegexThreatProtectionPolicyTest {
 
     @Test
     public void shouldRejectEvilParamName() {
-
         MultiValueMap<String, String> params = createParams();
         params.add("param-evil", "jkl");
 
@@ -189,7 +181,6 @@ public class RegexThreatProtectionPolicyTest {
 
     @Test
     public void shouldRejectEvilParamValue() {
-
         MultiValueMap<String, String> params = createParams();
         params.add("param2", "jkl-evil");
 
@@ -209,7 +200,6 @@ public class RegexThreatProtectionPolicyTest {
 
     @Test
     public void shouldIgnoreBody() {
-
         configuration.setCheckBody(false);
 
         ReadWriteStream<Buffer> readWriteStream = cut.onRequestContent(request, policyChain);
@@ -220,7 +210,6 @@ public class RegexThreatProtectionPolicyTest {
 
     @Test
     public void shouldCheckAndAcceptBody() {
-
         when(request.headers()).thenReturn(createHttpHeaders());
         configuration.setCheckBody(true);
 
@@ -235,7 +224,6 @@ public class RegexThreatProtectionPolicyTest {
 
     @Test
     public void shouldRejectEvilBody() {
-
         when(request.headers()).thenReturn(createHttpHeaders());
         configuration.setCheckBody(true);
 
@@ -250,7 +238,6 @@ public class RegexThreatProtectionPolicyTest {
 
     @Test
     public void shouldRejectEvilBodyCaseInsensitive() {
-
         when(request.headers()).thenReturn(createHttpHeaders());
         configuration.setCheckBody(true);
 
@@ -264,7 +251,6 @@ public class RegexThreatProtectionPolicyTest {
     }
 
     private HttpHeaders createHttpHeaders() {
-
         HttpHeaders headers = new HttpHeaders();
         headers.add("header1", "abc");
         headers.add("header1", "def");
@@ -274,7 +260,6 @@ public class RegexThreatProtectionPolicyTest {
     }
 
     private MultiValueMap<String, String> createParams() {
-
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("param1", "abc");
         params.add("param1", "def");


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7301
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.2.1-issues-7301-stop-propagate-request-3-10-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-regex-threat-protection/1.2.1-issues-7301-stop-propagate-request-3-10-SNAPSHOT/gravitee-policy-regex-threat-protection-1.2.1-issues-7301-stop-propagate-request-3-10-SNAPSHOT.zip)
  <!-- Version placeholder end -->
