### PR TITLE
fix: filter null values before to decode

### DIFF
--- a/src/main/java/io/gravitee/policy/threatprotection/regex/RegexThreatProtectionPolicy.java
+++ b/src/main/java/io/gravitee/policy/threatprotection/regex/RegexThreatProtectionPolicy.java
@@ -31,6 +31,10 @@ import io.gravitee.policy.api.annotations.OnRequestContent;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 /**
@@ -123,7 +127,7 @@ public class RegexThreatProtectionPolicy {
             .stream()
             .anyMatch(e ->
                 pattern.matcher(e.getKey()).matches() ||
-                e.getValue().stream().anyMatch(v -> pattern.matcher(decodeValues ? decode(v) : v).matches())
+                e.getValue().stream().filter(Objects::nonNull).anyMatch(v -> pattern.matcher(decodeValues ? decode(v) : v).matches())
             );
     }
 

--- a/src/test/java/io/gravitee/policy/threatprotection/regex/RegexThreatProtectionPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/threatprotection/regex/RegexThreatProtectionPolicyTest.java
@@ -259,6 +259,22 @@ public class RegexThreatProtectionPolicyTest {
         verify(policyChain, times(1)).streamFailWith(any(PolicyResult.class));
     }
 
+    @Test
+    public void shouldRejectPathTransversal() {
+        when(request.pathInfo()).thenReturn("/path/transversal/../path");
+        configuration.setCheckPath(true);
+        configuration.setRegex("^\\/?(.*\\.\\.).*$");
+
+        ReadWriteStream<?> readWriteStream = cut.onRequestContent(request, policyChain);
+        cut.onRequest(request, response, policyChain);
+
+        assertThat(readWriteStream).isNull();
+        verify(request, times(0)).headers();
+        verify(request, times(1)).pathInfo();
+        verify(request, times(0)).parameters();
+        verify(policyChain, times(1)).failWith(any(PolicyResult.class));
+    }
+
     private HttpHeaders createHttpHeaders() {
         HttpHeaders headers = new HttpHeaders();
         headers.add("header1", "abc");

--- a/src/test/java/io/gravitee/policy/threatprotection/regex/RegexThreatProtectionPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/threatprotection/regex/RegexThreatProtectionPolicyTest.java
@@ -290,6 +290,7 @@ public class RegexThreatProtectionPolicyTest {
         params.add("param1", "def");
         params.add("param2", "ghi");
         params.add("param2", "jkl");
+        params.add("boolean", null);
         return params;
     }
 


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8272
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.2.2-8272-fix-bool-param-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-regex-threat-protection/1.2.2-8272-fix-bool-param-SNAPSHOT/gravitee-policy-regex-threat-protection-1.2.2-8272-fix-bool-param-SNAPSHOT.zip)
  <!-- Version placeholder end -->
