### PR TITLE
Apim 2140 regex threatprotect

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,8 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@2.0
+    gravitee: gravitee-io/gravitee@4.1.0
+
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)
@@ -22,7 +23,7 @@ workflows:
     setup_release:
         when:
             matches:
-                pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+                pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
                 value: << pipeline.git.tag >>
         jobs:
             - gravitee/setup_plugin-release-config:
@@ -32,4 +33,4 @@ workflows:
                               - /.*/
                       tags:
                           only:
-                              - /^[0-9]+\.[0-9]+\.[0-9]+$/
+                              - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,14 +1,25 @@
 {
-  "extends": [
-    "config:base",
-    "schedule:earlyMondays"
-  ],
-  "prConcurrentLimit": 3,
+  "extends": ["config:base"],
   "rebaseWhen": "conflicted",
   "packageRules": [
     {
       "matchDatasources": ["orb"],
-      "rangeStrategy": "replace"
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "automergeType": "branch",
+      "semanticCommitType": "ci"
+    },
+    {
+      "matchDepTypes": ["provided", "test", "build", "import", "parent"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "automergeType": "branch",
+      "semanticCommitType": "chore"
+    },
+    {
+      "matchDepTypes": ["provided", "test", "build", "import", "parent"],
+      "matchUpdateTypes": ["major"],
+      "semanticCommitType": "chore"
     }
   ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -25,15 +25,16 @@
     <version>1.3.3</version>
 
     <name>Gravitee.io APIM - Policy - RegexThreatProtection</name>
-    <description>Description of the RegexThreatProtection Gravitee Policy</description>
+    <description>Regex threat protection policy</description>
 
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>19</version>
+        <version>21.0.1</version>
     </parent>
 
     <properties>
+        <gravitee-bom.version>5.0.0</gravitee-bom.version>
         <gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.9.0</gravitee-policy-api.version>
         <gravitee-common.version>1.17.2</gravitee-common.version>
@@ -43,6 +44,19 @@
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Import bom to properly inherit all dependencies -->
+            <dependency>
+                <groupId>io.gravitee</groupId>
+                <artifactId>gravitee-bom</artifactId>
+                <version>${gravitee-bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <!-- Provided scope -->
@@ -70,7 +84,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -6,3 +6,4 @@ class=io.gravitee.policy.threatprotection.regex.RegexThreatProtectionPolicy
 type=policy
 category=security
 icon=regex-threat-protection.svg
+proxy=REQUEST

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,18 +1,31 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "id": "urn:jsonschema:io:gravitee:policy:threatprotection:regex:RegexThreatProtectionPolicyConfiguration",
+  "additionalProperties": false,
   "properties": {
     "regex": {
       "title": "Regex",
-      "description": "Regex used to detect malicious injections. You can enable this regular expression on headers, path and body or add multiple Regex Threat Protection Policies with different regex depending on your needs.<br><br>Some regex detection examples:<ul><li>SQL Injection: <code>.*[\\s]*((delete)|(exec)|(drop\\s*table)|(insert)|(shutdown)|(update)|(\\bor\\b)).*</code></li><li>Server-Side Include Injection: <code>.*&lt;!--#(include|exec|echo|config|printenv)\\s+.*</code></li><li>Java Exception Injection: <code>.*Exception in thread.*</code></li><li>Javascript Injection: <code>.*<\\s*script\\b[^>]*>[^<]+<\\s*/\\s*script\\s*>.*</code></li><li>XPath Injection: <code>.*(/(@?[\\w_?\\w:\\*]+(\\[[^]]+\\])*)?)+.*</code></li></ul>",
+      "description": "Regex used to detect malicious injections.",
       "type": "string",
-      "format": "java-regex"
+      "format": "java-regex",
+      "gioConfig": {
+        "banner": {
+          "title": "Regex",
+          "text": "Regex used to detect malicious injections. You can enable this regular expression on headers, path and body or add multiple Regex Threat Protection Policies with different regex depending on your needs.<br><br>Some regex detection examples:<ul><li>SQL Injection: <code>.*[\\s]*((delete)|(exec)|(drop\\s*table)|(insert)|(shutdown)|(update)|(\\bor\\b)).*</code></li><li>Server-Side Include Injection: <code>.*&lt;!--#(include|exec|echo|config|printenv)\\s+.*</code></li><li>Java Exception Injection: <code>.*Exception in thread.*</code></li><li>Javascript Injection: <code>.*<\\s*script\\b[^>]*>[^<]+<\\s*/\\s*script\\s*>.*</code></li><li>XPath Injection: <code>.*(/(@?[\\w_?\\w:\\*]+(\\[[^]]+\\])*)?)+.*</code></li></ul>"
+        }
+      }
     },
     "caseSensitive": {
       "title": "Case sensitive",
-      "description": "Perform case sensitive matching.<br><strong>WARNING</strong>: Please beware that enabling case sensitive matching may let pass some risky patterns such as <code>DrOp TaBlE</code>.",
+      "description": "Perform case sensitive matching.",
       "type": "boolean",
-      "default": false
+      "default": false,
+      "gioConfig": {
+        "banner": {
+          "title": "Case sensitive",
+          "text": "Perform case sensitive matching.<br><strong>WARNING</strong>: Please beware that enabling case sensitive matching may let pass some risky patterns such as <code>DrOp TaBlE</code>."
+        }
+      }
     },
     "checkHeaders": {
       "title": "Check headers",

--- a/src/test/java/io/gravitee/policy/threatprotection/regex/RegexThreatProtectionPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/threatprotection/regex/RegexThreatProtectionPolicyTest.java
@@ -205,7 +205,7 @@ public class RegexThreatProtectionPolicyTest {
         ReadWriteStream<Buffer> readWriteStream = cut.onRequestContent(request, policyChain);
         assertThat(readWriteStream).isNull();
 
-        verifyZeroInteractions(policyChain);
+        verifyNoInteractions(policyChain);
     }
 
     @Test
@@ -222,7 +222,7 @@ public class RegexThreatProtectionPolicyTest {
 
         assertThat(hasCalledEndOnReadWriteStreamParentClass).isTrue();
 
-        verifyZeroInteractions(policyChain);
+        verifyNoInteractions(policyChain);
     }
 
     @Test


### PR DESCRIPTION
**Issue**

APIM-2140

**Description**
* upate renovate config
* update cci config
* update gravitee parent
* update schema form
* add execution phase
*
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.4.0-apim-2140-regex-threatprotect-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-regex-threat-protection/1.4.0-apim-2140-regex-threatprotect-SNAPSHOT/gravitee-policy-regex-threat-protection-1.4.0-apim-2140-regex-threatprotect-SNAPSHOT.zip)
  <!-- Version placeholder end -->
