### PR TITLE
feat: add a config option to handle full-matching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.1.0
+    gravitee: gravitee-io/gravitee@4.12.1
 
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise

--- a/README.adoc
+++ b/README.adoc
@@ -48,6 +48,12 @@ The policy injects processing report messages into request metrics for analytics
 ^.^|boolean
 ^.^|false
 
+.^|fullMatching
+^.^|
+|Perform full content matching. When enabled, the regex must match the entire content. Otherwise, the request will be rejected if the regex is found anywhere within the content.
+^.^|boolean
+^.^|true
+
 .^|checkHeaders
 ^.^|
 |Evaluate regex on request headers

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,21 @@
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/io/gravitee/policy/threatprotection/regex/RegexThreatProtectionPolicy.java
+++ b/src/main/java/io/gravitee/policy/threatprotection/regex/RegexThreatProtectionPolicy.java
@@ -33,10 +33,8 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.Charset;
 import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.function.Predicate;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -95,7 +93,8 @@ public class RegexThreatProtectionPolicy {
                 @Override
                 public void end() {
                     // Load the body in memory and execute the regex on it.
-                    if (configuration.getPattern().matcher(buffer.toString()).matches()) {
+                    Matcher matcher = configuration.getPattern().matcher(buffer.toString());
+                    if ((configuration.isFullMatching() && matcher.matches()) || (!configuration.isFullMatching() && matcher.find())) {
                         policyChain.streamFailWith(
                             PolicyResult.failure(
                                 REGEX_THREAT_BODY_DETECTED_KEY,

--- a/src/main/java/io/gravitee/policy/threatprotection/regex/RegexThreatProtectionPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/threatprotection/regex/RegexThreatProtectionPolicyConfiguration.java
@@ -64,6 +64,12 @@ public class RegexThreatProtectionPolicyConfiguration implements PolicyConfigura
     private boolean caseSensitive = false;
 
     /**
+     * Flag indicating if matching is full or not.
+     * Default is true (fullMatching).
+     */
+    private boolean fullMatching = true;
+
+    /**
      * Returns the compiled version of the regex.
      *
      * @return the compiled regex.
@@ -120,5 +126,13 @@ public class RegexThreatProtectionPolicyConfiguration implements PolicyConfigura
 
     public void setCaseSensitive(boolean caseSensitive) {
         this.caseSensitive = caseSensitive;
+    }
+
+    public boolean isFullMatching() {
+        return fullMatching;
+    }
+
+    public void setFullMatching(boolean fullMatching) {
+        this.fullMatching = fullMatching;
     }
 }

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -27,6 +27,12 @@
         }
       }
     },
+    "fullMatching": {
+      "title": "Full matching",
+      "description": "Perform full content matching. When enabled, the regex must match the entire content. Otherwise, the request will be rejected if the regex is found anywhere within the content.",
+      "type": "boolean",
+      "default": true
+    },
     "checkHeaders": {
       "title": "Check headers",
       "description": "Evaluate regex on request headers",


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-8219

**Description**

Add a config option in the Regex Threat Protection Policy to handle full-matching payload.

**Additional context**

Before:
<img width="1276" alt="Capture d’écran 2025-03-05 à 15 11 05" src="https://github.com/user-attachments/assets/af6f4e86-51b2-4d62-8869-87ad044b9633" />

After:
<img width="595" alt="Capture d’écran 2025-03-10 à 12 06 13" src="https://github.com/user-attachments/assets/3af32872-9b68-4445-9e59-207fa6f0528e" />


<img width="864" alt="Capture d’écran 2025-03-05 à 15 10 18" src="https://github.com/user-attachments/assets/06c31fc6-0a68-4205-9b16-e9be25f6c785" />


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.6.0-APIM-8219-fix-policy-handling-multilines-payload-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-regex-threat-protection/1.6.0-APIM-8219-fix-policy-handling-multilines-payload-SNAPSHOT/gravitee-policy-regex-threat-protection-1.6.0-APIM-8219-fix-policy-handling-multilines-payload-SNAPSHOT.zip)
  <!-- Version placeholder end -->
